### PR TITLE
RDKBDEV-2730: Enable breakpad support in RdkGponManager

### DIFF
--- a/source/GponManager/ssp_main.c
+++ b/source/GponManager/ssp_main.c
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
     fclose(fd);
 
 #ifdef INCLUDE_BREAKPAD
-//    breakpad_ExceptionHandler();
+    breakpad_ExceptionHandler();
     signal(SIGALRM, sig_handler);
 #else
     signal(SIGTERM, sig_handler);


### PR DESCRIPTION
Reason for change:
Uncommented the call of breakpad_ExceptionHandler to enable breakpad support.

Test Procedure: Sanity.
Risks: None.
Signed-off-by: K Sanjay Nayak <k-sanjay.nayak@t-systems.com>