### PR TITLE
RDKBDEV-2730: Enable breakpad support in RdkGponManager

### DIFF
--- a/source/GponManager/ssp_main.c
+++ b/source/GponManager/ssp_main.c
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
     fclose(fd);
 
 #ifdef INCLUDE_BREAKPAD
-//    breakpad_ExceptionHandler();
+    breakpad_ExceptionHandler();
     signal(SIGALRM, sig_handler);
 #else
     signal(SIGTERM, sig_handler);


### PR DESCRIPTION
Reason for change:
Enable breakpad support in RdkGponManager.

Test Procedure: Dump file need to generated during crash.
Risks: None.