### PR TITLE
RDKBDEV-2736: Fix for json_hal_server_gpon does not start when  WAN_MANAGER_UNIFICATION_ENABLED flag is enabled.

### DIFF
--- a/source/TR-181/middle_layer_src/gponmgr_dml_hal.c
+++ b/source/TR-181/middle_layer_src/gponmgr_dml_hal.c
@@ -100,7 +100,14 @@ ANSC_STATUS GponHal_Init()
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
     char wan_type[32] = {0};
 
-    v_secure_system("/bin/json_hal_server_gpon /etc/rdk/conf/gpon_manager_conf.json &");
+    if (access("/bin/json_hal_server_gpon", F_OK) == 0)
+    {
+        v_secure_system("/bin/json_hal_server_gpon  /etc/rdk/conf/gpon_manager_wan_unify_conf.json &");
+    }
+    else
+    {
+        v_secure_system("/usr/bin/json_hal_server_gpon  /etc/rdk/conf/gpon_manager_wan_unify_conf.json &");
+    }
 #endif
 
     if (json_hal_client_init(GPON_MANAGER_CONF_FILE) != RETURN_OK)


### PR DESCRIPTION
…NAGER_UNIFICATION_ENABLED flag is enabled.

Reason for change:
gpon_manager_wan_unify_conf.json is used when WAN_MANAGER_UNIFICATION_ENABLED.

Test Procedure: json_hal_server_gpon should be running and connected with GponManager.
Risks: None.