### PR TITLE
RDKB-58019 : Adding version log.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,11 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],
 
 
 
+#Add git version
+m4_define([GITVERSION],
+  m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
+)
+AC_SUBST([GIT_VERSION], [GITVERSION])
 
 dnl **********************************
 dnl checks for dependencies

--- a/source/GponManager/Makefile.am
+++ b/source/GponManager/Makefile.am
@@ -30,3 +30,4 @@ GponManager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
 GponManager_SOURCES = ssp_action.c ssp_messagebus_interface.c ssp_main.c gponmgr_controller.c gponmgr_link_state_machine.c dm_pack_datamodel.c
 GponManager_LDFLAGS = -lccsp_common -lrdkloggers -lsecure_wrapper $(DBUS_LIBS) $(SYSTEMD_LDFLAGS)
 GponManager_LDADD = $(GponManager_DEPENDENCIES)
+GponManager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"

--- a/source/GponManager/ssp_main.c
+++ b/source/GponManager/ssp_main.c
@@ -260,6 +260,7 @@ int main(int argc, char* argv[])
 
     //rdklogger init
     rdk_logger_init(DEBUG_INI_NAME);
+    CcspTraceInfo(("Version : %s \n",GIT_VERSION ));
 
     if ( bRunAsDaemon )
         daemonize();


### PR DESCRIPTION
Reason for change:  Adding version log using "git describe --tags --always --dirty" command Example :
RC2.7.0a-1-g5aa0583-dirty
Tag: RC2.7.0a (Most recent tag)
Number of Commits Ahead: -1 (1 commit after the tag) Commit Hash: g5aa0583 ( "5aa0583" Hash of the current commit) Uncommitted Changes: -dirty (Changes not yet committed)

Test Procedure:
Version log should be present.

Priority: P1
Risks: none