### PR TITLE
RDKCOM-5403: RDKBDEV-3238 remove dependency on dbus

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,8 +86,6 @@ dnl Checks for library functions.
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([memset strdup strerror])
 
-PKG_CHECK_MODULES([DBUS],[dbus-1 >= 1.6.18])
-
 AC_CONFIG_FILES([Makefile
                 source/Makefile
                 source/TR-181/Makefile

--- a/source/GponManager/Makefile.am
+++ b/source/GponManager/Makefile.am
@@ -26,8 +26,8 @@ GponManager_DEPENDENCIES = \
 GponManager_CPPFLAGS = -I$(top_srcdir)/source/TR-181/middle_layer_src \
                        -I$(top_srcdir)/source/TR-181/include
 
-GponManager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
+GponManager_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(SYSTEMD_CFLAGS)
 GponManager_SOURCES = ssp_action.c ssp_messagebus_interface.c ssp_main.c gponmgr_controller.c gponmgr_link_state_machine.c dm_pack_datamodel.c
-GponManager_LDFLAGS = -lccsp_common -lrdkloggers -lsecure_wrapper $(DBUS_LIBS) $(SYSTEMD_LDFLAGS)
+GponManager_LDFLAGS = -lccsp_common -lrdkloggers -lsecure_wrapper $(SYSTEMD_LDFLAGS)
 GponManager_LDADD = $(GponManager_DEPENDENCIES)
 GponManager_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"

--- a/source/GponManager/ssp_messagebus_interface.c
+++ b/source/GponManager/ssp_messagebus_interface.c
@@ -114,7 +114,6 @@ ANSC_STATUS ssp_Mbi_MessageBusEngage (char * component_id,char * config_file,cha
 
     CcspBaseIf_SetCallback(bus_handle, &cb);
 
-
     /* Register event/signal */
     returnStatus =
         CcspBaseIf_Register_Event


### PR DESCRIPTION
Reason for change:
Removing all D-Bus related code and its build dependencies from the CCSP components, as the binaries for each CCSP process are still linked with D-Bus libraries despite no longer being required. Test Procedure: Sanity.
Risks: None.
Test Procedure: Sanity.
Risks: None.
Signed-off-by: qlei <rlei@libertyglobal.com>
